### PR TITLE
Add support for without_hashes setting in poetry projects

### DIFF
--- a/lambda_packager/handle_poetry.py
+++ b/lambda_packager/handle_poetry.py
@@ -9,10 +9,9 @@ class PoetryNotInstalled(Exception):
 
 
 def poetry_is_used(current_directory):
-    pyproject = current_directory.joinpath("pyproject.toml")
-    if not pyproject.is_file():
+    config = _get_poetry_config(current_directory)
+    if config is None:
         return False
-    config = toml.loads(pyproject.read_text())
 
     try:
         requires = config["build-system"]["requires"][0].startswith("poetry")
@@ -24,19 +23,37 @@ def poetry_is_used(current_directory):
 
 
 def export_poetry(target_path, project_directory=None, env=None):
+    if project_directory is not None:
+        config = _get_poetry_config(project_directory)
+    else:
+        config = None
+
+    export_without_hashes = False
+
+    if config is not None:
+        try:
+            export_without_hashes = config["tool"]["lambda-packager"]["without_hashes"]
+        except KeyError:
+            pass
+
     try:
+        cmd = [
+            "poetry",
+            "export",
+            "--no-interaction",
+            "--verbose",
+            "--with-credentials",
+            "--format",
+            "requirements.txt",
+            "--output",
+            target_path,
+        ]
+
+        if export_without_hashes:
+            cmd.append("--without-hashes")
+
         subprocess.check_output(
-            [
-                "poetry",
-                "export",
-                "--no-interaction",
-                "--verbose",
-                "--with-credentials",
-                "--format",
-                "requirements.txt",
-                "--output",
-                target_path,
-            ],
+            cmd,
             env=env,
             cwd=project_directory,
         )
@@ -47,3 +64,10 @@ def export_poetry(target_path, project_directory=None, env=None):
     except subprocess.CalledProcessError as e:
         logging.error(e.stdout.decode())
         raise e
+
+
+def _get_poetry_config(current_directory):
+    pyproject = current_directory.joinpath("pyproject.toml")
+    if not pyproject.is_file():
+        return None
+    return toml.loads(pyproject.read_text())

--- a/test/resources/test_project_config_without_hashes.toml
+++ b/test/resources/test_project_config_without_hashes.toml
@@ -1,0 +1,15 @@
+[tool.lambda-packager]
+without_hashes = true
+
+[tool.poetry]
+name = "EXAMPLE_PYPROJECT"
+version = "0.1.0"
+description = "EXAMPLE_PYPROJECT"
+authors = ["EXAMPLE_PYPROJECT"]
+
+[tool.poetry.dependencies]
+pip-install-test = "^0.5"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
https://github.com/hmrc/python-aws-lambda-packager/issues/2

If your project has a dependency on a github depot lambda-packager throws an error during package creation. This prevents me from being able to use my own shared libraries as dependencies with lambda-packager.

Workaround to add an option to export your poetry dependencies without hashes.