### PR TITLE
Add options to allow dependencies to be split from source in a lambda layer

### DIFF
--- a/lambda_packager/config.py
+++ b/lambda_packager/config.py
@@ -6,6 +6,7 @@ class Config:
         ignore_folders=None,
         without_hashes=False,
         deps_only=False,
+        layer=False,
     ):
         if ignore_folders is None:
             ignore_folders = []
@@ -18,3 +19,4 @@ class Config:
         self.ignore_hidden_files = ignore_hidden_files
         self.without_hashes = without_hashes
         self.deps_only = deps_only
+        self.layer = layer

--- a/lambda_packager/config.py
+++ b/lambda_packager/config.py
@@ -5,6 +5,7 @@ class Config:
         ignore_hidden_files=True,
         ignore_folders=None,
         without_hashes=False,
+        deps_only=False,
     ):
         if ignore_folders is None:
             ignore_folders = []
@@ -16,3 +17,4 @@ class Config:
         self.src_patterns = src_patterns
         self.ignore_hidden_files = ignore_hidden_files
         self.without_hashes = without_hashes
+        self.deps_only = deps_only

--- a/lambda_packager/package.py
+++ b/lambda_packager/package.py
@@ -60,10 +60,13 @@ class LambdaAutoPackage:
         else:
             self.logger.warning("No dependency found, none will be packaged")
 
-        self._copy_source_files(
-            source_dir=self.project_directory,
-            target_dir=self.tmp_folder,
-        )
+        if self.config.deps_only:
+            self.logger.info("--deps-only flag present, src files will be ignored")
+        else:
+            self._copy_source_files(
+                source_dir=self.project_directory,
+                target_dir=self.tmp_folder,
+            )
 
         self._create_zip_file(
             self.tmp_folder, str(self.project_directory.joinpath("dist/lambda.zip"))

--- a/lambda_packager/package.py
+++ b/lambda_packager/package.py
@@ -77,11 +77,6 @@ class LambdaAutoPackage:
             )
 
             if not self.config.deps_only:
-                self._copy_source_files(
-                    source_dir=self.project_directory,
-                    target_dir=self.src_folder,
-                )
-
                 self._create_zip_file(
                     self.src_folder,
                     str(self.project_directory.joinpath("dist/lambda-src.zip")),

--- a/test/resources/test_config_deps_only.toml
+++ b/test/resources/test_config_deps_only.toml
@@ -1,0 +1,2 @@
+[tool.lambda-packager]
+deps_only = true

--- a/test/resources/test_project_config_deps_only.toml
+++ b/test/resources/test_project_config_deps_only.toml
@@ -1,0 +1,15 @@
+[tool.poetry]
+name = "EXAMPLE_PYPROJECT"
+version = "0.1.0"
+description = "EXAMPLE_PYPROJECT"
+authors = ["EXAMPLE_PYPROJECT"]
+
+[tool.poetry.dependencies]
+pip-install-test = "^0.5"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.lambda-packager]
+deps_only = true

--- a/test/resources/test_project_config_layer.toml
+++ b/test/resources/test_project_config_layer.toml
@@ -1,0 +1,15 @@
+[tool.poetry]
+name = "EXAMPLE_PYPROJECT"
+version = "0.1.0"
+description = "EXAMPLE_PYPROJECT"
+authors = ["EXAMPLE_PYPROJECT"]
+
+[tool.poetry.dependencies]
+pip-install-test = "^0.5"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.lambda-packager]
+layer = true

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -75,6 +75,29 @@ def test_build_lambda_with_requirements_txt(caplog):
     assert "not_this_file" not in zip.namelist()
 
 
+def test_build_lambda_with_deps_only_requirements(caplog):
+    test_path = LambdaAutoPackage._create_tmp_directory()
+
+    test_file_helpers.with_requirements_file(test_path)
+    test_config = Path("test/resources/test_config_deps_only.toml")
+    test_file_helpers.with_config_file(test_path, test_config)
+
+    file1 = test_path.joinpath("test_file_1")
+    file1.write_text("test file 1")
+
+    with caplog.at_level(logging.INFO):
+        LambdaAutoPackage(project_directory=test_path).execute()
+
+    assert "--deps-only flag present, src files will be ignored" in caplog.text
+
+    actual_zip = test_path.joinpath("dist/lambda.zip")
+    assert actual_zip.is_file()
+
+    zip = zipfile.ZipFile(actual_zip)
+    assert "test_file_1" not in zip.namelist()
+    assert "pip_install_test/__init__.py" in zip.namelist()
+
+
 def test_build_lambda_with_pyproject_toml(caplog):
     test_path = LambdaAutoPackage._create_tmp_directory()
     test_file_helpers.with_poetry_toml_file(test_path)
@@ -96,6 +119,27 @@ def test_build_lambda_with_pyproject_toml(caplog):
     zip = zipfile.ZipFile(actual_zip)
     assert "test_file_1.py" in zip.namelist()
     assert "not_this_file.md" not in zip.namelist()
+
+
+def test_build_lambda_deps_only_pyproject_toml(caplog):
+    test_path = LambdaAutoPackage._create_tmp_directory()
+    test_config = Path("test/resources/test_project_config_deps_only.toml")
+    test_file_helpers.with_config_file(test_path, test_config)
+
+    file1 = test_path.joinpath("test_file_1.py")
+    file1.write_text("test file 1")
+
+    with caplog.at_level(logging.INFO):
+        LambdaAutoPackage(project_directory=test_path).execute()
+
+    assert "--deps-only flag present, src files will be ignored" in caplog.text
+
+    actual_zip = test_path.joinpath("dist/lambda.zip")
+    assert actual_zip.is_file()
+
+    zip = zipfile.ZipFile(actual_zip)
+    assert "test_file_1.py" not in zip.namelist()
+    assert "pip_install_test/__init__.py" in zip.namelist()
 
 
 def test_error_when_no_requirements_text_is_installed():


### PR DESCRIPTION
Adds two options to use when creating a lambda layer:

deps_only = true
The package will only include dependencies, source files are excluded

layer = true
The package will be split into lambda-src.zip and lambda-deps.zip, containing only source and dependencies respectively.